### PR TITLE
Fix some flaws in planner and its storage

### DIFF
--- a/src/main/java/seedu/kolinux/planner/Planner.java
+++ b/src/main/java/seedu/kolinux/planner/Planner.java
@@ -84,7 +84,10 @@ public class Planner {
     }
 
     /**
-     * Initializes the planner by loading the previously saved schedule in planner.txt.
+     * Initializes the planner by loading the previously saved schedule in planner.txt. File lines
+     * that are not able to construct an Event will be removed, and the new file lines will be
+     * rewritten back to the storage. Hence, only corrupted lines will be removed while the rest of
+     * the file data can still be added as Events to the planner.
      *
      * @throws KolinuxException If the file cannot be read properly due to corruption
      */

--- a/src/main/java/seedu/kolinux/planner/PlannerStorage.java
+++ b/src/main/java/seedu/kolinux/planner/PlannerStorage.java
@@ -60,7 +60,7 @@ public class PlannerStorage {
     }
 
     /**
-     * Reads from the file with the name planner.txt
+     * Reads from the file with the name planner.txt. Empty lines will be ignored and skipped.
      *
      * @return Array list where each entry is a line from the file, null if the file does not exist.
      */


### PR DESCRIPTION
empty lines will be skipped when reading in file
only corrupted lines will be removed from the file, the rest of the file can still be added to the planner upon initPlanner()